### PR TITLE
fix: update app title and tests to match 'Simple Drawing Board'

### DIFF
--- a/app/src/app/app.component.spec.ts
+++ b/app/src/app/app.component.spec.ts
@@ -14,16 +14,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'app' title`, () => {
+  it(`should have the 'Simple Drawing Board' title`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('app');
+    expect(app.title).toEqual('Simple Drawing Board');
   });
 
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, app');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, Simple Drawing Board');
   });
 });

--- a/app/src/app/app.component.ts
+++ b/app/src/app/app.component.ts
@@ -8,5 +8,5 @@ import { RouterOutlet } from '@angular/router';
   styleUrl: './app.component.css',
 })
 export class AppComponent {
-  title = 'app';
+  title = 'Simple Drawing Board';
 }


### PR DESCRIPTION
- Update AppComponent title property from 'app' to 'Simple Drawing Board'
- Fix failing tests to expect correct title values
- Tests now pass both locally and in CI pipeline

Resolves test failures in GitHub Actions workflow