### PR TITLE
fix: update unit test to match actual component title rendering

### DIFF
--- a/app/src/app/app.component.spec.ts
+++ b/app/src/app/app.component.spec.ts
@@ -24,6 +24,6 @@ describe('AppComponent', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, Simple Drawing Board');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Simple Drawing Board');
   });
 });


### PR DESCRIPTION
- Fixed test expectation from 'Hello, Simple Drawing Board' to 'Simple Drawing Board'
- Test now matches the actual template output which renders just the title without 'Hello, ' prefix
- All 10 tests now pass successfully