### PR TITLE
fix: align ECR repository name with deployment configuration

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -130,7 +130,7 @@ output "ubuntu2404_public_ip" {
 
 # INFO : https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_repository
 resource "aws_ecr_repository" "myecr" {
-  name                 = "m324/myapp"
+  name                 = "m324-gruppenarbeit"
   image_tag_mutability = "MUTABLE"
   encryption_configuration {
     encryption_type = "KMS"


### PR DESCRIPTION
- Change ECR repository name from 'm324/myapp' to 'm324-gruppenarbeit'
- This matches the DOCKER_IMAGE_NAME in GitHub workflows
- Ensures consistency between Terraform infrastructure and deployment configs
- Resolves potential image push/pull issues during deployment

Infrastructure components now properly aligned:
- Terraform ECR: m324-gruppenarbeit
- GitHub Workflow: m324-gruppenarbeit
- Kamal Config: m324-gruppenarbeit