### PR TITLE
fix: add force_delete to ECR repository configuration

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -132,6 +132,7 @@ output "ubuntu2404_public_ip" {
 resource "aws_ecr_repository" "myecr" {
   name                 = "m324-gruppenarbeit"
   image_tag_mutability = "MUTABLE"
+  force_delete         = true
   encryption_configuration {
     encryption_type = "KMS"
   }


### PR DESCRIPTION
- Add force_delete = true to allow deletion of non-empty ECR repositories
- Resolves RepositoryNotEmptyException when transitioning from m324/myapp to m324-gruppenarbeit
- Enables clean repository recreation without manual image cleanup
- Ensures smooth Terraform deployment process

This allows Terraform to automatically handle the deletion of the existing ECR repository with images and create the new one with consistent naming.