### PR TITLE
fix: remove duplicate registry URL from Kamal image configuration

### DIFF
--- a/kamal/config/deploy.yml
+++ b/kamal/config/deploy.yml
@@ -2,7 +2,7 @@
 service: m324-gruppenarbeit
 
 # Name of the container image.
-image: <%= ENV["KAMAL_REGISTRY"] %>/m324-gruppenarbeit
+image: m324-gruppenarbeit
 
 # Deploy to these servers.
 servers:


### PR DESCRIPTION
- Change image from '<%= ENV["KAMAL_REGISTRY"] %>/m324-gruppenarbeit' to 'm324-gruppenarbeit'
- Kamal automatically prepends the registry URL from registry.server config
- This prevents the duplicate registry URL issue in image path
- Fixes deployment error: repository not found due to malformed path

Before: registry.com/registry.com/m324-gruppenarbeit (duplicate)
After:  registry.com/m324-gruppenarbeit (correct)